### PR TITLE
fix: responsive layout for mobile viewports

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -15,7 +15,7 @@
 	let { children, data }: Props = $props();
 </script>
 
-<Card.Root class="flex-1 flex flex-col h-full">
+<Card.Root class="flex-1 flex flex-col h-full w-full max-w-full overflow-hidden">
 	<Card.Header class="flex flex-row gap-2 items-center justify-between relative pt-3">
 		<Button variant="ghost" href="/my-clips" class="py-8 flex flex-row gap-2 items-center justify-between">
 			<Avatar.Root>
@@ -41,7 +41,9 @@
 		{/if}
 	</Card.Header>
 	<Separator class="mt-3" />
-	<Card.Content class="flex flex-col justify-evenly items-center h-full overflow-auto">
+	<Card.Content
+		class="flex flex-col justify-evenly items-center h-full w-full max-w-full overflow-y-auto overflow-x-hidden"
+	>
 		{@render children()}
 	</Card.Content>
 </Card.Root>

--- a/src/routes/(app)/clip/[clipId]/clip-player.svelte
+++ b/src/routes/(app)/clip/[clipId]/clip-player.svelte
@@ -131,16 +131,16 @@
 		</div>
 	</Card.Content>
 	<Card.Footer>
-		<div class="w-full flex justify-between">
+		<div class="w-full flex flex-col md:flex-row gap-2 md:gap-0 md:justify-between">
 			{#if clip.userId !== currentUser.jellyfinUserId}
 				<Button variant="destructive" onclick={() => deleteConfirmation?.withConfirmation(() => onDeleteClip())}>
 					<i class="text-xl ph ph-trash"></i>
 					Delete Clip
 				</Button>
 			{:else}
-				<div></div>
+				<div class="hidden md:block"></div>
 			{/if}
-			<div class="flex gap-2">
+			<div class="flex flex-wrap gap-2">
 				<Button variant="outline" onclick={onCopyUrl}>
 					<i class="text-xl ph ph-copy-simple"></i>
 					Copy Link

--- a/src/routes/(app)/create-clip/+page.svelte
+++ b/src/routes/(app)/create-clip/+page.svelte
@@ -23,15 +23,15 @@
 	let buttonIsDisabled = $derived(isNavigating || sourceUrl.length === 0);
 </script>
 
-<div class="flex flex-col h-full w-1/2 justify-evenly gap-4 py-10">
+<div class="flex flex-col h-full w-full md:w-1/2 justify-evenly gap-4 py-10">
 	<div class="flex flex-col gap-4">
 		<h1 class="text-2xl font-bold text-center">Welcome to Jelly-Clipper!</h1>
 		<h3 class="text-lg text-center">Create clips from your favorite movies and shows</h3>
 	</div>
 	{#if data.latestItems.length > 0}
-		<div>
+		<div class="w-full min-w-0">
 			<h2 class="text-xl font-semibold mb-2">From your latest watched items</h2>
-			<div class="flex flex-row gap-4 overflow-x-auto py-4">
+			<div class="flex flex-row gap-4 overflow-x-auto py-4 w-full">
 				{#each data.latestItems as item (item.Id)}
 					<a
 						class="flex-shrink-0 w-48 hover:scale-105 transition-transform"

--- a/src/routes/(app)/create-clip/[source]/video-clipper.svelte
+++ b/src/routes/(app)/create-clip/[source]/video-clipper.svelte
@@ -192,7 +192,7 @@
 		items={subtitleItems}
 		type="single"
 	>
-		<Select.Trigger class="w-[400px]">
+		<Select.Trigger class="w-full md:w-[400px]">
 			{selectedSubtitleTrackItem?.label ?? 'Select Subtitle Track'}
 		</Select.Trigger>
 		<Select.Content>

--- a/src/routes/(app)/prepare-clip/[source]/+page.svelte
+++ b/src/routes/(app)/prepare-clip/[source]/+page.svelte
@@ -36,10 +36,10 @@
 	let isNavigating = $derived(!!navigating.to);
 </script>
 
-<main class="flex flex-col h-full w-1/2 items-center justify-evenly gap-4">
+<main class="flex flex-col h-full w-full md:w-1/2 items-center justify-evenly gap-4">
 	<h3 class="text-lg text-center">Please select which audio track you want to use</h3>
-	<div class="flex flex-row gap-4">
-		<div class="flex flex-col gap-2">
+	<div class="flex flex-row gap-4 w-full md:w-auto">
+		<div class="flex flex-col gap-2 w-full md:w-auto">
 			<Label>Audio track</Label>
 			<Select.Root
 				bind:value={
@@ -49,7 +49,7 @@
 				items={audioTrackItems}
 				type="single"
 			>
-				<Select.Trigger class="min-w-[400px] gap-2">
+				<Select.Trigger class="w-full md:min-w-[400px] gap-2">
 					{selectedAudioTrack?.label ?? 'Select Audio Track'}
 				</Select.Trigger>
 				<Select.Content>
@@ -63,7 +63,7 @@
 		</div>
 	</div>
 
-	<Button class="w-1/2" data-sveltekit-preload-data="off" disabled={isNavigating} href={createClipUrl}>
+	<Button class="w-full md:w-1/2" data-sveltekit-preload-data="off" disabled={isNavigating} href={createClipUrl}>
 		{#if isNavigating}
 			Loading...
 		{:else}


### PR DESCRIPTION
This PR intends to improve the mobile responsiveness a bit.
The applied changes are purely for CSS and should be more or less minimal.
Text is not cutoff anymore, neither the input text field.

-----
BTW, thanks for this repo, it's amazing for quickly snipping highlights from pets-at-home videos