### PR TITLE
Scrub via Jellyfin stream

### DIFF
--- a/src/lib/server/services/JellyfinService.ts
+++ b/src/lib/server/services/JellyfinService.ts
@@ -17,6 +17,7 @@ import { MediaSourceSchema, type MediaSource } from '$lib/shared/MediaSource';
 import { BaseItemDtoSchema } from '$lib/shared/BaseItemDto';
 import { MediaStreamSchema } from '$lib/shared/MediaStream';
 import { LatestMediaSchema, type LatestMedia } from '$lib/shared/LatestMediaSchema';
+import { buildPreviewStreamUrl } from './jellyfin-preview-url';
 
 type JellyfinSdkApi = ReturnType<Jellyfin['createApi']>;
 
@@ -136,6 +137,12 @@ export class JellyfinApi extends Context.Tag('JellyfinApi')<
 			DatabaseError | JellyClipperNotConfiguredError | JellyfinApiError | NoCurrentUserError | ParseError
 		>;
 		getDownloadStreamUrl: (
+			params: GetDownloadStreamParams
+		) => Effect.Effect<
+			string,
+			DatabaseError | JellyClipperNotConfiguredError | JellyfinApiError | NoCurrentUserError | ParseError
+		>;
+		getStreamPreviewUrl: (
 			params: GetDownloadStreamParams
 		) => Effect.Effect<
 			string,
@@ -327,6 +334,31 @@ export class JellyfinApi extends Context.Tag('JellyfinApi')<
 				return directPlayUrl;
 			});
 
+			const getStreamPreviewUrl = Effect.fn('JellyfinApi.getStreamPreviewUrl')(function* (
+				params: GetDownloadStreamParams
+			) {
+				const { itemId, mediaSourceId, audioStreamIndex, subtitleStreamIndex } = params;
+				const user = yield* currentUser.getCurrentUser();
+				const { api } = yield* getJellyfinApi();
+				const { mediaSource, sessionId } = yield* createPlaybackSession({
+					itemId,
+					mediaSourceId,
+					audioStreamIndex,
+					subtitleStreamIndex
+				});
+				return buildPreviewStreamUrl({
+					basePath: api.basePath,
+					itemId,
+					mediaSourceId: mediaSource?.Id ?? mediaSourceId,
+					playSessionId: sessionId,
+					apiKey: api.accessToken,
+					deviceId: api.deviceInfo.id,
+					userId: user.id,
+					audioStreamIndex,
+					subtitleStreamIndex
+				});
+			});
+
 			const getClipInfo = Effect.fn('MediaInfoService.getClipInfo')(function* (sourceId: string) {
 				const info = yield* getItemInfo(sourceId);
 				const mediaSource = info?.MediaSources?.[0];
@@ -355,6 +387,7 @@ export class JellyfinApi extends Context.Tag('JellyfinApi')<
 				getSubtitleTracks,
 				createPlaybackSession,
 				getDownloadStreamUrl,
+				getStreamPreviewUrl,
 				getClipInfo,
 				getLatestWatchedMedia: Effect.fn('JellyfinApi.getLatestWatchedMedia')(function* () {
 					const user = yield* currentUser.getCurrentUser();

--- a/src/lib/server/services/LibraryService.ts
+++ b/src/lib/server/services/LibraryService.ts
@@ -17,9 +17,9 @@ export class LibraryService extends Context.Tag('LibraryService')<
 		 */
 		getMediaFormatInfo: (item: BaseItemDto) => Effect.Effect<MediaFormatInfo, ItemFileNotFound>;
 		/**
-		 * Checks if the original media file for the given item is available locally and in a widely compatible format.
-		 * If so, it symlinks the file to the originals directory for use in clipping.
-		 * Returns format information regardless of compatibility.
+		 * Symlinks the item's local source file into the originals directory, regardless
+		 * of codec. Browser playback for incompatible codecs is handled separately via
+		 * a Jellyfin live-transcoded HLS URL.
 		 */
 		checkForLocalMediaFile: (
 			item: BaseItemDto
@@ -141,16 +141,7 @@ export class LibraryService extends Context.Tag('LibraryService')<
 							!SUPPORTED_CODECS.includes(videoInfo.codec) || !SUPPORTED_CONTAINERS.includes(videoInfo.container)
 					};
 
-					if (!SUPPORTED_CODECS.includes(videoInfo.codec) || !SUPPORTED_CONTAINERS.includes(videoInfo.container)) {
-						yield* Effect.logWarning(
-							`Media file at path: ${jellyfinItemPath} has incompatible codec/container: ${videoInfo.codec}/${videoInfo.container}`
-						);
-						return yield* new ItemFileNotFound({
-							message: `Media file has incompatible codec/container: ${videoInfo.codec}/${videoInfo.container}`
-						});
-					}
-
-					// If the file exists, we symlink it to our originals directory
+					// Symlink unconditionally; cut uses server-side ffmpeg which handles any codec.
 					yield* fs.symlink(jellyfinItemPath, `${assetService.ORIGINALS_DIR}/${item.Id}.mp4`).pipe(
 						Effect.catchAll((error) =>
 							Effect.fail(

--- a/src/lib/server/services/jellyfin-preview-url.test.ts
+++ b/src/lib/server/services/jellyfin-preview-url.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { buildPreviewStreamUrl, DEFAULT_PREVIEW_VIDEO_BITRATE } from './jellyfin-preview-url';
+
+const baseParams = {
+	basePath: 'https://jellyfin.example.test',
+	itemId: 'item-abc',
+	mediaSourceId: 'src-xyz',
+	playSessionId: 'sess-1',
+	apiKey: 'secret-key',
+	deviceId: 'device-7',
+	userId: 'user-42'
+};
+
+describe('buildPreviewStreamUrl', () => {
+	it('points at the master HLS playlist for the item', () => {
+		const url = new URL(buildPreviewStreamUrl(baseParams));
+		expect(`${url.origin}${url.pathname}`).toBe('https://jellyfin.example.test/Videos/item-abc/master.m3u8');
+	});
+
+	it('forces transcoding to h264/aac inside an mp4 container', () => {
+		const url = new URL(buildPreviewStreamUrl(baseParams));
+		expect(url.searchParams.get('videoCodec')).toBe('h264');
+		expect(url.searchParams.get('audioCodec')).toBe('aac');
+		expect(url.searchParams.get('container')).toBe('mp4');
+		expect(url.searchParams.get('static')).toBe('false');
+	});
+
+	it('uses videoBitRate (encoder param), not maxStreamingBitrate (device-profile param)', () => {
+		const url = new URL(buildPreviewStreamUrl(baseParams));
+		expect(url.searchParams.get('videoBitRate')).toBe(String(DEFAULT_PREVIEW_VIDEO_BITRATE));
+		expect(url.searchParams.has('maxStreamingBitrate')).toBe(false);
+	});
+
+	it('honours an overridden videoBitRate', () => {
+		const url = new URL(buildPreviewStreamUrl({ ...baseParams, videoBitRate: 4_000_000 }));
+		expect(url.searchParams.get('videoBitRate')).toBe('4000000');
+	});
+
+	it('threads identity and session params through', () => {
+		const url = new URL(buildPreviewStreamUrl(baseParams));
+		expect(url.searchParams.get('mediaSourceId')).toBe('src-xyz');
+		expect(url.searchParams.get('playSessionId')).toBe('sess-1');
+		expect(url.searchParams.get('api_key')).toBe('secret-key');
+		expect(url.searchParams.get('deviceId')).toBe('device-7');
+		expect(url.searchParams.get('userId')).toBe('user-42');
+	});
+
+	it('omits stream indices when not provided', () => {
+		const url = new URL(buildPreviewStreamUrl(baseParams));
+		expect(url.searchParams.get('audioStreamIndex')).toBe('');
+		expect(url.searchParams.get('subtitleStreamIndex')).toBe('');
+	});
+
+	it('serialises stream indices when provided', () => {
+		const url = new URL(buildPreviewStreamUrl({ ...baseParams, audioStreamIndex: 2, subtitleStreamIndex: 0 }));
+		expect(url.searchParams.get('audioStreamIndex')).toBe('2');
+		expect(url.searchParams.get('subtitleStreamIndex')).toBe('0');
+	});
+});

--- a/src/lib/server/services/jellyfin-preview-url.ts
+++ b/src/lib/server/services/jellyfin-preview-url.ts
@@ -1,0 +1,38 @@
+export const DEFAULT_PREVIEW_VIDEO_BITRATE = 10_000_000;
+
+export interface BuildPreviewStreamUrlParams {
+	basePath: string;
+	itemId: string;
+	mediaSourceId: string;
+	playSessionId: string;
+	apiKey: string;
+	deviceId: string;
+	userId: string;
+	audioStreamIndex?: number;
+	subtitleStreamIndex?: number;
+	videoBitRate?: number;
+}
+
+/** Build a Jellyfin HLS URL that forces a transcode to h264/aac/mp4. */
+export function buildPreviewStreamUrl(params: BuildPreviewStreamUrlParams): string {
+	const streamParams = new URLSearchParams({
+		mediaSourceId: params.mediaSourceId,
+		subtitleStreamIndex: params.subtitleStreamIndex?.toString() ?? '',
+		audioStreamIndex: params.audioStreamIndex?.toString() ?? '',
+		deviceId: params.deviceId,
+		api_key: params.apiKey,
+		startTimeTicks: '0',
+		videoBitRate: (params.videoBitRate ?? DEFAULT_PREVIEW_VIDEO_BITRATE).toString(),
+		userId: params.userId,
+		subtitleMethod: 'Embed',
+		static: 'false',
+		allowVideoStreamCopy: 'true',
+		allowAudioStreamCopy: 'true',
+		playSessionId: params.playSessionId,
+		container: 'mp4',
+		videoCodec: 'h264',
+		audioCodec: 'aac',
+		subtitleCodec: 'srt'
+	});
+	return `${params.basePath}/Videos/${params.itemId}/master.m3u8?${streamParams.toString()}`;
+}

--- a/src/routes/(app)/create-clip/[source]/+page.server.ts
+++ b/src/routes/(app)/create-clip/[source]/+page.server.ts
@@ -1,6 +1,7 @@
 import type { PageServerLoad } from './$types';
 import { Effect, pipe, Schema } from 'effect';
-import { DownloadMediaService } from '$lib/server/services/DownloadMediaService';
+import { DownloadMediaService, type DownloadResult } from '$lib/server/services/DownloadMediaService';
+import { BigIntFileSize } from '$lib/shared/FileSizes';
 import { makeAuthenticatedRuntimeLayer } from '$lib/server/services/UserSession';
 import { AssetService } from '$lib/server/services/AssetService';
 import { runLoader } from '$lib/server/load-utils';
@@ -65,13 +66,14 @@ export const load: PageServerLoad = async (event) =>
 				.pipe(Effect.catchAll(() => Effect.succeed(null)));
 
 			let previewUrl: string | undefined;
+			let symlinked = false;
 
 			if (formatResult) {
 				formatInfo = formatResult;
 
 				// Symlink any local source
 				const symlinkResult = yield* libraryService.checkForLocalMediaFile(itemInfo.info).pipe(Effect.either);
-				const symlinked = symlinkResult._tag === 'Right';
+				symlinked = symlinkResult._tag === 'Right';
 
 				// Browser can't decode the source iso give the player a Jellyfin HLS transcode URL
 				if (symlinked && formatResult.requiresDownload) {
@@ -86,26 +88,36 @@ export const load: PageServerLoad = async (event) =>
 				}
 			}
 
-			// Don't yield* here, we want to run the download and pass the promise back to the client
-			const downloadProgram = pipe(
-				downloadEffect(itemInfo.info.Id, audioStreamIndex),
-				Effect.withLogSpan('create-clip.downloadEffect'),
-				Effect.provide(makeAuthenticatedRuntimeLayer(event.locals))
-			);
+			// Skip the download when symlinked: cut reads the source via the symlink,
+			// preview reads it via previewUrl (incompatible codec) or directly (compatible).
+			let downloadResult: Promise<DownloadResult | { errorMessage: string }>;
+			if (symlinked) {
+				downloadResult = Promise.resolve({
+					fileInfo: { name: itemInfo.info.Id, extension: 'mp4', size: BigIntFileSize.make(0n) },
+					subtitleTracks: []
+				});
+			} else {
+				// Don't yield* here, we want to run the download and pass the promise back to the client
+				const downloadProgram = pipe(
+					downloadEffect(itemInfo.info.Id, audioStreamIndex),
+					Effect.withLogSpan('create-clip.downloadEffect'),
+					Effect.provide(makeAuthenticatedRuntimeLayer(event.locals))
+				);
 
-			yield* Effect.logDebug(`Forking download fiber for item ${itemInfo.info.Id}`);
-			const downloadFiber = yield* fiberManager.startDownloadFiber(itemInfo.info.Id, downloadProgram);
-			yield* Effect.logDebug(`Returning download promise for item ${itemInfo.info.Id}`, downloadFiber.id());
-			const downloadResult = Effect.runPromiseExit(downloadFiber).then((exit) => {
-				if (exit._tag === 'Success') {
-					return exit.value;
-				} else {
-					if (exit.cause._tag === 'Fail') {
-						return { errorMessage: `${exit.cause.error._tag}: ${exit.cause.error.message}` };
+				yield* Effect.logDebug(`Forking download fiber for item ${itemInfo.info.Id}`);
+				const downloadFiber = yield* fiberManager.startDownloadFiber(itemInfo.info.Id, downloadProgram);
+				yield* Effect.logDebug(`Returning download promise for item ${itemInfo.info.Id}`, downloadFiber.id());
+				downloadResult = Effect.runPromiseExit(downloadFiber).then((exit) => {
+					if (exit._tag === 'Success') {
+						return exit.value;
+					} else {
+						if (exit.cause._tag === 'Fail') {
+							return { errorMessage: `${exit.cause.error._tag}: ${exit.cause.error.message}` };
+						}
+						return { errorMessage: `An unexpected error occurred: ${exit.cause.toString()}` };
 					}
-					return { errorMessage: `An unexpected error occurred: ${exit.cause.toString()}` };
-				}
-			});
+				});
+			}
 
 			return new OkLoader({ data: { itemInfo: itemInfo.info, download: downloadResult, formatInfo, previewUrl } });
 		}).pipe(

--- a/src/routes/(app)/create-clip/[source]/+page.server.ts
+++ b/src/routes/(app)/create-clip/[source]/+page.server.ts
@@ -64,12 +64,25 @@ export const load: PageServerLoad = async (event) =>
 				.getMediaFormatInfo(itemInfo.info)
 				.pipe(Effect.catchAll(() => Effect.succeed(null)));
 
+			let previewUrl: string | undefined;
+
 			if (formatResult) {
 				formatInfo = formatResult;
 
-				// If format is compatible, try to symlink it
-				if (!formatResult.requiresDownload) {
-					yield* libraryService.checkForLocalMediaFile(itemInfo.info).pipe(Effect.catchAll(() => Effect.succeed(null)));
+				// Symlink any local source
+				const symlinkResult = yield* libraryService.checkForLocalMediaFile(itemInfo.info).pipe(Effect.either);
+				const symlinked = symlinkResult._tag === 'Right';
+
+				// Browser can't decode the source iso give the player a Jellyfin HLS transcode URL
+				if (symlinked && formatResult.requiresDownload) {
+					const mediaSource = itemInfo.info.MediaSources?.[0];
+					if (mediaSource?.Id) {
+						previewUrl = yield* api.getStreamPreviewUrl({
+							itemId: itemInfo.info.Id,
+							mediaSourceId: mediaSource.Id,
+							audioStreamIndex: audioStreamIndex !== null ? audioStreamIndex : undefined
+						});
+					}
 				}
 			}
 
@@ -94,7 +107,7 @@ export const load: PageServerLoad = async (event) =>
 				}
 			});
 
-			return new OkLoader({ data: { itemInfo: itemInfo.info, download: downloadResult, formatInfo } });
+			return new OkLoader({ data: { itemInfo: itemInfo.info, download: downloadResult, formatInfo, previewUrl } });
 		}).pipe(
 			Effect.provide(makeAuthenticatedRuntimeLayer(event.locals)),
 			Effect.catchTag('BadArgument', (error) => Effect.fail(new BadRequest({ message: error.message }))),

--- a/src/routes/(app)/create-clip/[source]/+page.svelte
+++ b/src/routes/(app)/create-clip/[source]/+page.svelte
@@ -33,13 +33,15 @@
 
 			const compatible = isFormatCompatible(codec, container, audioCodec);
 
-			needsDownload = !compatible;
+			needsDownload = !compatible && !data.previewUrl;
 			isCheckingCompatibility = false;
 
 			if (compatible) {
 				compatibilityMessage = `Using local file (${codec}/${container})`;
+			} else if (data.previewUrl) {
+				compatibilityMessage = `Source is ${codec}/${container} - scrubbing live transcode, cut from local source`;
 			} else {
-				compatibilityMessage = `Format not compatible (${codec}/${container}). Downloading transcoded version...`;
+				compatibilityMessage = `Format not compatible (${codec}/${container}). Downloading...`;
 			}
 		} else {
 			// No format info or file not available locally, need to download
@@ -96,9 +98,14 @@
 		{#await data.download then resultExit}
 			{#if 'fileInfo' in resultExit}
 				{@const { fileInfo, subtitleTracks } = resultExit}
-				<VideoClipper sourceId={fileInfo.name} sourceInfo={data.itemInfo} {subtitleTracks} />
+				<VideoClipper
+					sourceId={fileInfo.name}
+					sourceInfo={data.itemInfo}
+					{subtitleTracks}
+					previewUrl={data.previewUrl}
+				/>
 			{:else}
-				<VideoClipper sourceId={data.itemInfo.Id} sourceInfo={data.itemInfo} />
+				<VideoClipper sourceId={data.itemInfo.Id} sourceInfo={data.itemInfo} previewUrl={data.previewUrl} />
 			{/if}
 		{/await}
 	</div>

--- a/src/routes/(app)/create-clip/[source]/video-clipper.svelte
+++ b/src/routes/(app)/create-clip/[source]/video-clipper.svelte
@@ -27,9 +27,10 @@
 		sourceId: string;
 		sourceInfo: BaseItemDto | OriginalBaseItemDto;
 		subtitleTracks?: ReadonlyArray<Track> | OldTrack[];
+		previewUrl?: string;
 	};
 
-	let { sourceId, sourceInfo, subtitleTracks }: Props = $props();
+	let { sourceId, sourceInfo, subtitleTracks, previewUrl }: Props = $props();
 
 	let player: MediaPlayerElement | null = $state(null);
 	const remoteControl = new MediaRemoteControl();
@@ -234,7 +235,11 @@
 		>
 			<div bind:this={triggerEl} style="visibility: none;"></div>
 			<media-provider>
-				<source src="/videos/originals/{sourceId}.mp4" type="video/mp4" />
+				{#if previewUrl}
+					<source src={previewUrl} type="application/x-mpegURL" />
+				{:else}
+					<source src="/videos/originals/{sourceId}.mp4" type="video/mp4" />
+				{/if}
 			</media-provider>
 			<media-video-layout></media-video-layout>
 		</media-player>


### PR DESCRIPTION
Follow up PR for #228.
Seems to work reasonably well on my system:tm:.
We essentially offload to jellyfin transcoding instead of downloading the vid ourselves.

Not sure if the download-path is really needed anymore, but I have left it in for now. Upon request, I can submit a follow-up commit to this PR that removes the download option.
For the scope of this PR, downloads only happen if symlinking fails, which effectively only happens if you deploy the clipper on a system that does not share data paths with jellyfin. IMO questionable to do so, but removing the download path is a feature removal that warrants a proper maintainer decision.
I guess it depends on if people really depend on this. Safest option is to just keep.

LMK what you think of the changes and if things should've been done differently.